### PR TITLE
Pin working version of makeWrapper, unpin nixpkgs

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,10 +1,3 @@
-{...}:
+{ pkgs ? import <nixpkgs> { }, ... }:
 
-let
-  pkgs = import (builtins.fetchTarball {
-    url = "https://github.com/nixos/nixpkgs/archive/21.11.tar.gz";
-    sha256 = "162dywda2dvfj1248afxc45kcrg83appjd0nmdb541hl7rnncf02";
-  }) {};
-in
-
-pkgs.callPackage ./nix-cl.nix {}
+pkgs.callPackage ./nix-cl.nix { }

--- a/nix-cl.nix
+++ b/nix-cl.nix
@@ -396,6 +396,13 @@ let
       lispLibs' = editTree libs (map replaceLib);
     in unique lispLibs';
 
+  # The recent version of makeWrapper causes breakage. For more info see
+  # https://github.com/Uthar/nix-cl/issues/2
+  oldMakeWrapper = (import (builtins.fetchTarball {
+    url = "https://github.com/nixos/nixpkgs/archive/37809af15e22cc4b1e3de3a9fad98b612881f6a5.tar.gz";
+    sha256 = "0ay907qpvmzr3vhhc6bhwrwz6cdwiadbyxjqlq9wi4f2ldr1id59";
+  }) {}).makeWrapper;
+
   # Creates a lisp wrapper with `packages` installed
   #
   # `packages` is a function that takes `clpkgs` - a set of lisp
@@ -410,7 +417,7 @@ let
       pname = baseNameOf (head (split " " lisp));
       version = "with-packages";
       lispLibs = fixDuplicateAsds (packages clpkgs) clpkgs;
-      buildInputs = with pkgs; [ makeWrapper ];
+      nativeBuildInputs = [ oldMakeWrapper ];
       systems = [];
     }).overrideAttrs(o: {
       installPhase = ''

--- a/shell.nix
+++ b/shell.nix
@@ -1,13 +1,8 @@
-let
-  pkgs = import (builtins.fetchTarball {
-    url = "https://github.com/nixos/nixpkgs/archive/21.11.tar.gz";
-    sha256 = "162dywda2dvfj1248afxc45kcrg83appjd0nmdb541hl7rnncf02";
-  }) {};
-  nix-cl = import ./. {};
-in
-
-pkgs.mkShell {
-  buildInputs = [
-    (nix-cl.sbclWithPackages (ps: with ps; [ alexandria str dexador cl-ppcre sqlite ]))
+{ pkgs ? import <nixpkgs> { } }:
+let nix-cl = import ./. { inherit pkgs; };
+in pkgs.mkShell {
+  nativeBuildInputs = [
+    (nix-cl.sbclWithPackages
+      (ps: with ps; [ alexandria str dexador cl-ppcre sqlite ]))
   ];
 }


### PR DESCRIPTION
This pins a makeWrapper version right before a breaking commit. It allows to use any nixpkgs tree that is being handed into the root expression again.