### PR TITLE
Add mcclim (broken)

### DIFF
--- a/packages.nix
+++ b/packages.nix
@@ -255,6 +255,22 @@ let
     ];
   };
 
+  mcclim-clx-fb = build-with-compile-into-pwd {
+    inherit (super.mcclim-clx-fb) pname version src lispLibs nativeBuildInputs nativeLibs;
+  };
+
+  mcclim-clx = build-with-compile-into-pwd {
+    inherit (super.mcclim-clx) pname version src lispLibs nativeBuildInputs nativeLibs;
+  };
+
+  mcclim-bezier = build-with-compile-into-pwd {
+    inherit (super.mcclim-bezier) pname version src lispLibs nativeBuildInputs nativeLibs;
+  };
+
+  mcclim-render = build-with-compile-into-pwd {
+    inherit (super.mcclim-render) pname version src lispLibs nativeBuildInputs nativeLibs;
+  };
+
   mathkit = build-asdf-system {
     inherit (super.mathkit) pname version src asds ;
     lispLibs = super.mathkit.lispLibs ++ [ super.sb-cga ];


### PR DESCRIPTION
Happy new year! :dagger: 

I'm trying to pull in McCLIM but I'm seeing an error that's harder than usual to fix:

```
$ NIXPKGS_ALLOW_BROKEN=1 nix develop --override-input nix-cl ~/git/nix-cl --impure --command sbcl
warning: Git tree '/home/luke/git/permo' is dirty
warning: not writing modified lock file of flake 'git+file:///home/luke/git/permo':
• Updated input 'nix-cl':
    'github:uthar/nix-cl/714702632ecc58622f78b23f12ca01e0f142b2d0' (2023-01-23)
  → 'git+file:///home/luke/git/nix-cl?ref=refs%2fheads%2fmcclim&rev=d0b87d8d14068364cfb541f863e5943632bae8db' (2023-02-06)
error: builder for '/nix/store/nn6djdlzsb0zxdpkzia6818ghnxp8n5r-mcclim-bezier-20221106-git-build.drv' failed with exit code 1;
       last 10 log lines:
       > ; compiling file "/build/source/Extensions/fonts/ttf-medium-mixin.lisp" (written 01 JAN 1970 12:00:01 AM):
       >
       > ; wrote /build/source/__fasls/Extensions/fonts/ttf-medium-mixin-tmpJAIDFZTC.fasl
       > ; compilation finished in 0:00:00.034
       > ;
       > ; compilation unit aborted
       > ;   caught 1 fatal ERROR condition
       > BUILD FAILED: Error opening #P"/nix/store/n1kx34zfinb3whhrbci327jch6anjz2b-mcclim-render-20221106-git/Extensions/render/package-tmp8V3J6PE9.fasl":
       >
       >                 Permission denied
       For full logs, run 'nix log /nix/store/nn6djdlzsb0zxdpkzia6818ghnxp8n5r-mcclim-bezier-20221106-git-build.drv'.
error: 1 dependencies of derivation '/nix/store/ngxxv0ys5rslgnlc0crzrzcy93r34swf-mcclim-bezier-20221106-git.drv' failed to build
error: 1 dependencies of derivation '/nix/store/yxh1wp51gq9b5dgp6wrmk03q7kpbd9ki-mcclim-20221106-git.drv' failed to build
error: 1 dependencies of derivation '/nix/store/wzsncs5y0rfx4nkyn7d3y7sij400v7m3-sbcl-with-packages.drv' failed to build
error: 1 dependencies of derivation '/nix/store/lb2vg8i8m9q4y1bvi8i5nxgmbsv71x1l-nix-shell-env.drv' failed to build
```

I figured that the `Permission denied` error is a dead giveaway that `mcclim-render` needs to be wrapped in `build-with-compile-into-pwd` except... I already did that. Any ideas on why it would be failing?