### PR TITLE
Don't remove the skeleton.asd in cl-project

### DIFF
--- a/nix-cl.nix
+++ b/nix-cl.nix
@@ -147,6 +147,10 @@ let
       # TODO(kasper): remove
       asds ? systems,
 
+      # Files wich have a .asd suffix but should be included in the build output
+      # anyway.
+      extraAsds ? [],
+
       # Other args to mkDerivation
       ...
     } @ args:
@@ -211,7 +215,7 @@ let
 
         # Remove all .asd files except for those in `systems`.
         find $out -name "*.asd" \
-        | grep -v "/\(${mkSystemsRegex systems}\)\.asd$" \
+        | grep -v "/\(${mkSystemsRegex (systems ++ extraAsds)}\)\.asd$" \
         | xargs rm -fv || true
       '';
 

--- a/packages.nix
+++ b/packages.nix
@@ -496,7 +496,10 @@ let
       trivial-extensible-sequences
     ];
   };
-  
+
+  cl-project = super.cl-project.overrideLispAttrs (o: {
+    extraAsds = [ "skeleton/skeleton" ];
+  });
   });
 
 in packages


### PR DESCRIPTION
`cl-project` is used for creating new common lisp projects. As such, it normally creates a `.asd` file which is generated from the template `skeleton/skeleton.asd`. If this file is missing, cl-project is silently skipping the creation of a `.asd` file for the new project. Thus there needs to be an escape hatch from removing all `.asd` files during the `installPhase` without building that `.asd` file.

